### PR TITLE
feat(api): 添加 LLM 服务的 gRPC 接口和数据模型

### DIFF
--- a/api/gen/ai/v1/ai.pb.go
+++ b/api/gen/ai/v1/ai.pb.go
@@ -21,6 +21,8 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// LLMRequest is a request message for invoking LLM services.
+// Contains optional id and text parameters for processing.
 type LLMRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -29,6 +31,8 @@ type LLMRequest struct {
 	sizeCache     protoimpl.SizeCache
 }
 
+// Reset resets the LLMRequest to its zero value state.
+// This clears all fields and resets internal protobuf state.
 func (x *LLMRequest) Reset() {
 	*x = LLMRequest{}
 	mi := &file_ai_v1_ai_proto_msgTypes[0]
@@ -36,12 +40,17 @@ func (x *LLMRequest) Reset() {
 	ms.StoreMessageInfo(mi)
 }
 
+// String returns the string representation of the LLMRequest message.
+// Implements the Stringer interface for LLMRequest.
 func (x *LLMRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// ProtoMessage marks LLMRequest as implementing the protobuf Message interface.
 func (*LLMRequest) ProtoMessage() {}
 
+// ProtoReflect returns the protobuf reflection information for this message.
+// Provides access to the message descriptor and implementation details.
 func (x *LLMRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_ai_v1_ai_proto_msgTypes[0]
 	if x != nil {
@@ -54,11 +63,13 @@ func (x *LLMRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use LLMRequest.ProtoReflect.Descriptor instead.
+// Descriptor returns the raw protobuf descriptor for this message type.
+// Deprecated: Use ProtoReflect.Descriptor instead.
 func (*LLMRequest) Descriptor() ([]byte, []int) {
 	return file_ai_v1_ai_proto_rawDescGZIP(), []int{0}
 }
 
+// GetId returns the Id field value, or an empty string if the field is not set.
 func (x *LLMRequest) GetId() string {
 	if x != nil {
 		return x.Id
@@ -66,6 +77,7 @@ func (x *LLMRequest) GetId() string {
 	return ""
 }
 
+// GetText returns the Text field value, or an empty string if the field is not set.
 func (x *LLMRequest) GetText() string {
 	if x != nil {
 		return x.Text
@@ -73,6 +85,8 @@ func (x *LLMRequest) GetText() string {
 	return ""
 }
 
+// StreamEvent represents a streaming event in the LLM service communication.
+// Contains status flags and content data for streaming responses.
 type StreamEvent struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	Final            bool                   `protobuf:"varint,1,opt,name=final,proto3" json:"final,omitempty"`
@@ -83,6 +97,8 @@ type StreamEvent struct {
 	sizeCache        protoimpl.SizeCache
 }
 
+// Reset resets the StreamEvent to its zero value state.
+// This clears all fields and resets internal protobuf state.
 func (x *StreamEvent) Reset() {
 	*x = StreamEvent{}
 	mi := &file_ai_v1_ai_proto_msgTypes[1]
@@ -90,12 +106,17 @@ func (x *StreamEvent) Reset() {
 	ms.StoreMessageInfo(mi)
 }
 
+// String returns the string representation of the StreamEvent message.
+// Implements the Stringer interface for StreamEvent.
 func (x *StreamEvent) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// ProtoMessage marks StreamEvent as implementing the protobuf Message interface.
 func (*StreamEvent) ProtoMessage() {}
 
+// ProtoReflect returns the protobuf reflection information for this message.
+// Provides access to the message descriptor and implementation details.
 func (x *StreamEvent) ProtoReflect() protoreflect.Message {
 	mi := &file_ai_v1_ai_proto_msgTypes[1]
 	if x != nil {
@@ -108,11 +129,13 @@ func (x *StreamEvent) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use StreamEvent.ProtoReflect.Descriptor instead.
+// Descriptor returns the raw protobuf descriptor for this message type.
+// Deprecated: Use ProtoReflect.Descriptor instead.
 func (*StreamEvent) Descriptor() ([]byte, []int) {
 	return file_ai_v1_ai_proto_rawDescGZIP(), []int{1}
 }
 
+// GetFinal returns whether this stream event is the final message in the stream.
 func (x *StreamEvent) GetFinal() bool {
 	if x != nil {
 		return x.Final
@@ -120,6 +143,8 @@ func (x *StreamEvent) GetFinal() bool {
 	return false
 }
 
+// GetReasoningContent returns the reasoning content from the stream event,
+// or an empty string if the field is not set.
 func (x *StreamEvent) GetReasoningContent() string {
 	if x != nil {
 		return x.ReasoningContent
@@ -127,6 +152,8 @@ func (x *StreamEvent) GetReasoningContent() string {
 	return ""
 }
 
+// GetContent returns the content from the stream event,
+// or an empty string if the field is not set.
 func (x *StreamEvent) GetContent() string {
 	if x != nil {
 		return x.Content
@@ -134,6 +161,8 @@ func (x *StreamEvent) GetContent() string {
 	return ""
 }
 
+// GetErr returns any error message associated with the stream event,
+// or an empty string if no error occurred.
 func (x *StreamEvent) GetErr() string {
 	if x != nil {
 		return x.Err
@@ -141,6 +170,8 @@ func (x *StreamEvent) GetErr() string {
 	return ""
 }
 
+// LLMResponse represents a complete response from the LLM service.
+// Contains processed content and reasoning information.
 type LLMResponse struct {
 	state            protoimpl.MessageState `protogen:"open.v1"`
 	ReasoningContent string                 `protobuf:"bytes,1,opt,name=reasoningContent,proto3" json:"reasoningContent,omitempty"`
@@ -149,6 +180,8 @@ type LLMResponse struct {
 	sizeCache        protoimpl.SizeCache
 }
 
+// Reset resets the LLMResponse to its zero value state.
+// This clears all fields and resets internal protobuf state.
 func (x *LLMResponse) Reset() {
 	*x = LLMResponse{}
 	mi := &file_ai_v1_ai_proto_msgTypes[2]
@@ -156,12 +189,17 @@ func (x *LLMResponse) Reset() {
 	ms.StoreMessageInfo(mi)
 }
 
+// String returns the string representation of the LLMResponse message.
+// Implements the Stringer interface for LLMResponse.
 func (x *LLMResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+// ProtoMessage marks LLMResponse as implementing the protobuf Message interface.
 func (*LLMResponse) ProtoMessage() {}
 
+// ProtoReflect returns the protobuf reflection information for this message.
+// Provides access to the message descriptor and implementation details.
 func (x *LLMResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_ai_v1_ai_proto_msgTypes[2]
 	if x != nil {
@@ -174,11 +212,14 @@ func (x *LLMResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use LLMResponse.ProtoReflect.Descriptor instead.
+// Descriptor returns the raw protobuf descriptor for this message type.
+// Deprecated: Use ProtoReflect.Descriptor instead.
 func (*LLMResponse) Descriptor() ([]byte, []int) {
 	return file_ai_v1_ai_proto_rawDescGZIP(), []int{2}
 }
 
+// GetReasoningContent returns the reasoning content from the response,
+// or an empty string if the field is not set.
 func (x *LLMResponse) GetReasoningContent() string {
 	if x != nil {
 		return x.ReasoningContent
@@ -186,6 +227,8 @@ func (x *LLMResponse) GetReasoningContent() string {
 	return ""
 }
 
+// GetContent returns the content from the response,
+// or an empty string if the field is not set.
 func (x *LLMResponse) GetContent() string {
 	if x != nil {
 		return x.Content
@@ -220,6 +263,8 @@ var (
 	file_ai_v1_ai_proto_rawDescData []byte
 )
 
+// file_ai_v1_ai_proto_rawDescGZIP returns the GZIP-compressed raw descriptor
+// for the ai/v1/ai.proto file. This contains the complete protobuf schema.
 func file_ai_v1_ai_proto_rawDescGZIP() []byte {
 	file_ai_v1_ai_proto_rawDescOnce.Do(func() {
 		file_ai_v1_ai_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_ai_v1_ai_proto_rawDesc), len(file_ai_v1_ai_proto_rawDesc)))
@@ -245,7 +290,12 @@ var file_ai_v1_ai_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for field type_name
 }
 
+// init initializes the file descriptor for ai/v1/ai.proto.
+// This sets up the protobuf metadata for all messages defined in this file.
 func init() { file_ai_v1_ai_proto_init() }
+
+// file_ai_v1_ai_proto_init performs the actual initialization of the file descriptor.
+// It creates the type information for all messages and services defined in ai/v1/ai.proto.
 func file_ai_v1_ai_proto_init() {
 	if File_ai_v1_ai_proto != nil {
 		return

--- a/api/proto/ai/v1/ai.proto
+++ b/api/proto/ai/v1/ai.proto
@@ -1,25 +1,36 @@
+// 指定proto3语法版本
 syntax = "proto3";
+
+// 定义包名
 package ai.v1;
+
+// 指定生成的Go包路径和名称
 option go_package = "ai/v1;aiv1";
 
+// AI服务定义
 service AIService {
+  // 同步调用接口
   rpc Invoke(LLMRequest) returns (LLMResponse);
+  // 流式调用接口
   rpc Stream(LLMRequest) returns (stream StreamEvent);
 }
 
+// LLM请求消息
 message LLMRequest {
-  string id = 1;
-  string text = 2;
+  string id = 1;      // 请求ID
+  string text = 2;    // 输入文本
 }
 
+// 流式事件消息
 message StreamEvent {
-  bool final = 1;
-  string reasoningContent = 2;
-  string content = 3;
-  string err = 4;
+  bool final = 1;             // 是否为最终事件
+  string reasoningContent = 2; // 推理过程内容
+  string content = 3;         // 输出内容
+  string err = 4;             // 错误信息
 }
 
+// LLM响应消息
 message LLMResponse {
-  string reasoningContent = 1;
-  string content = 2;
+  string reasoningContent = 1; // 推理过程内容
+  string content = 2;         // 输出内容
 }

--- a/cmd/admin/bizconfig.go
+++ b/cmd/admin/bizconfig.go
@@ -12,6 +12,13 @@ import (
 	"gorm.io/gorm"
 )
 
+// main 函数是程序的入口点
+// 主要职责:
+//  1. 初始化基础设施
+//  2. 建立数据库连接
+//  3. 创建并配置 Gin 框架实例
+//  4. 注册路由
+//  5. 启动 HTTP 服务器
 func main() {
 	infra.Init()
 	db := initDB()
@@ -22,6 +29,9 @@ func main() {
 }
 
 // initDB 初始化数据库并自动建表
+// 返回值:
+//
+//	*gorm.DB - 初始化后的数据库连接实例
 func initDB() *gorm.DB {
 	db, err := gorm.Open(mysql.Open("root:root@tcp(localhost:13306)/ai_gateway_platform"))
 	if err != nil {
@@ -35,6 +45,13 @@ func initDB() *gorm.DB {
 }
 
 // InitBizConfigService 初始化 BizConfigService 实例
+// 参数:
+//
+//	db *gorm.DB - 数据库连接实例
+//
+// 返回值:
+//
+//	*web.BizConfigHandler - 业务配置处理器实例
 func initBizConfig(db *gorm.DB) *web.BizConfigHandler {
 	dao := dao.NewBizConfigDAO(db)
 	repo := repository.NewBizConfigRepository(dao)

--- a/cmd/platform/server.go
+++ b/cmd/platform/server.go
@@ -13,15 +13,33 @@ import (
 	"github.com/gotomicro/ego/server/egrpc"
 )
 
+// Server 配置并返回一个 gRPC 服务器实例。
+// 返回值:
+// - server.Server: 配置好的 gRPC 服务器实例。
+// 功能说明:
+// - 从配置中获取 DeepSeek 的 token。
+// - 创建一个新的 DeepSeek 客户端和处理程序。
+// - 使用处理程序创建 AI 服务实例。
+// - 加载并构建 gRPC 服务器配置。
+// - 注册 AI 服务到 gRPC 服务器。
 func Server() server.Server {
 	token := econf.GetString("deepseek.token")
+	// 创建 DeepSeek 客户端和处理程序
 	handler := deepseek.NewHandler(ds.NewClient(token))
+	// 创建 AI 服务实例
 	svc := service.NewAIService(handler)
+	// 加载并构建 gRPC 服务器配置
 	build := egrpc.Load("grpc.server").Build()
+	// 注册 AI 服务到 gRPC 服务器
 	ai.RegisterAIServiceServer(build.Server, igrpc.NewServer(svc))
 	return build
 }
 
+// main 启动应用程序并运行 gRPC 服务器。
+// 功能说明:
+// - 创建一个新的 Ego 应用实例。
+// - 使用 Server 函数配置应用的服务。
+// - 启动应用并监听错误，如果启动失败则记录 panic 日志。
 func main() {
 	if err := ego.New().Serve(Server()).Run(); err != nil {
 		elog.Panic("startup", elog.Any("err", err))

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -7,15 +7,34 @@ import (
 	"github.com/ecodeclub/ai-gateway-go/internal/service"
 )
 
+// Server 是一个 gRPC 服务器结构体，实现了 ai.AIServiceServer 接口。
+// 它包含一个内部的服务实例和一个未实现的 gRPC 服务接口。
 type Server struct {
 	svc *service.AIService
 	ai.UnimplementedAIServiceServer
 }
 
+// NewServer 创建一个新的 Server 实例。
+// 参数:
+//
+//	svc: 内部服务实例。
+//
+// 返回值:
+//
+//	指向新创建的 Server 实例的指针。
 func NewServer(svc *service.AIService) *Server {
 	return &Server{svc: svc}
 }
 
+// Invoke 处理来自客户端的同步调用请求。
+// 参数:
+//
+//	ctx: 上下文对象，用于控制请求生命周期。
+//	r:   LLMRequest 请求对象，包含请求的数据。
+//
+// 返回值:
+//
+//	LLMResponse 响应对象，包含处理结果或错误信息。
 func (server *Server) Invoke(ctx context.Context, r *ai.LLMRequest) (*ai.LLMResponse, error) {
 	resp, err := server.svc.Invoke(
 		ctx,
@@ -28,6 +47,15 @@ func (server *Server) Invoke(ctx context.Context, r *ai.LLMRequest) (*ai.LLMResp
 	return &ai.LLMResponse{Content: resp.Content}, nil
 }
 
+// Stream 处理流式请求。
+// 参数:
+//
+//	r:   LLMRequest 请求对象，包含请求的数据。
+//	resp: AIService_StreamServer 接口，用于发送流式响应。
+//
+// 返回值:
+//
+//	错误信息（如果有）。
 func (server *Server) Stream(r *ai.LLMRequest, resp ai.AIService_StreamServer) error {
 	ctx := resp.Context()
 
@@ -42,6 +70,16 @@ func (server *Server) Stream(r *ai.LLMRequest, resp ai.AIService_StreamServer) e
 	return server.stream(ctx, ch, resp)
 }
 
+// stream 发送流式响应给客户端。
+// 参数:
+//
+//	ctx: 上下文对象，用于控制请求生命周期。
+//	ch:  流事件通道，用于接收流事件。
+//	resp: AIService_StreamServer 接口，用于发送流式响应。
+//
+// 返回值:
+//
+//	错误信息（如果有）。
 func (server *Server) stream(ctx context.Context, ch chan domain.StreamEvent, resp ai.AIService_StreamServer) error {
 	var err error
 	for {

--- a/internal/repository/bizconfig.go
+++ b/internal/repository/bizconfig.go
@@ -9,14 +9,33 @@ import (
 	"time"
 )
 
+// BizConfigRepository 是业务配置的仓库实现，负责在领域模型和数据访问层之间进行转换。
 type BizConfigRepository struct {
-	dao *dao.BizConfigDAO
+	dao *dao.BizConfigDAO // 数据访问对象，用于操作数据库
 }
 
+// NewBizConfigRepository 创建一个新的BizConfigRepository实例。
+// 参数:
+//
+//	dao: 数据访问对象实例
+//
+// 返回值:
+//
+//	*BizConfigRepository: 初始化后的BizConfigRepository实例
 func NewBizConfigRepository(dao *dao.BizConfigDAO) *BizConfigRepository {
 	return &BizConfigRepository{dao: dao}
 }
 
+// Create 将一个新的业务配置记录插入数据库。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	config: 要插入的业务配置对象
+//
+// 返回值:
+//
+//	domain.BizConfig: 插入成功的业务配置对象
+//	error: 插入过程中发生的错误
 func (r *BizConfigRepository) Create(ctx context.Context, config domain.BizConfig) (domain.BizConfig, error) {
 	daoBC, err := r.dao.Insert(ctx, toDAOConfig(config))
 	if err != nil {
@@ -25,6 +44,16 @@ func (r *BizConfigRepository) Create(ctx context.Context, config domain.BizConfi
 	return fromDAOConfig(daoBC), nil
 }
 
+// GetByID 根据ID查询业务配置。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	id: 要查询的配置ID
+//
+// 返回值:
+//
+//	domain.BizConfig: 查询到的业务配置对象
+//	error: 查询过程中发生的错误
 func (r *BizConfigRepository) GetByID(ctx context.Context, id int64) (domain.BizConfig, error) {
 	bc, err := r.dao.GetByID(ctx, id)
 	if err != nil {
@@ -36,14 +65,40 @@ func (r *BizConfigRepository) GetByID(ctx context.Context, id int64) (domain.Biz
 	return fromDAOConfig(bc), nil
 }
 
+// Update 更新现有的业务配置记录。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	config: 包含更新数据的业务配置对象
+//
+// 返回值:
+//
+//	error: 更新过程中发生的错误
 func (r *BizConfigRepository) Update(ctx context.Context, config domain.BizConfig) error {
 	return r.dao.Update(ctx, toDAOConfig(config))
 }
 
+// Delete 根据ID删除业务配置记录。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	id: 要删除的配置ID
+//
+// 返回值:
+//
+//	error: 删除过程中发生的错误
 func (r *BizConfigRepository) Delete(ctx context.Context, id string) error {
 	return r.dao.Delete(ctx, id)
 }
 
+// toDAOConfig 将领域模型的BizConfig转换为DAO层的BizConfig。
+// 参数:
+//
+//	config: 领域模型的BizConfig对象
+//
+// 返回值:
+//
+//	*dao.BizConfig: DAO层的BizConfig对象
 func toDAOConfig(config domain.BizConfig) *dao.BizConfig {
 	return &dao.BizConfig{
 		ID:        config.ID,
@@ -55,6 +110,14 @@ func toDAOConfig(config domain.BizConfig) *dao.BizConfig {
 	}
 }
 
+// fromDAOConfig 将DAO层的BizConfig转换为领域模型的BizConfig。
+// 参数:
+//
+//	bc: DAO层的BizConfig对象
+//
+// 返回值:
+//
+//	domain.BizConfig: 领域模型的BizConfig对象
 func fromDAOConfig(bc dao.BizConfig) domain.BizConfig {
 	return domain.BizConfig{
 		ID:        bc.ID,

--- a/internal/repository/dao/bizconfig.go
+++ b/internal/repository/dao/bizconfig.go
@@ -6,27 +6,41 @@ import (
 	"time"
 )
 
+// BizConfig 结构体定义
+// 表示业务配置信息，用于存储不同所有者的配置数据
 type BizConfig struct {
-	ID        int64  `gorm:"column:id;primaryKey;autoIncrement"`
-	OwnerID   int64  `gorm:"column:owner_id;type:bigint;not null"`
-	OwnerType string `gorm:"column:owner_type;type:varchar(20);not null"`
-	Config    string `gorm:"column:config;type:text"`
-	Ctime     int64
-	Utime     int64
+	ID        int64  `gorm:"column:id;primaryKey;autoIncrement"`          // 配置的唯一标识符
+	OwnerID   int64  `gorm:"column:owner_id;type:bigint;not null"`        // 所有者ID（如用户ID或组织ID）
+	OwnerType string `gorm:"column:owner_type;type:varchar(20);not null"` // 所有者类型：如"user"或"organization"
+	Config    string `gorm:"column:config;type:text"`                     // 配置内容，通常存储JSON格式数据
+	Ctime     int64  `gorm:"column:ctime"`                                // 创建时间戳（毫秒）
+	Utime     int64  `gorm:"column:utime"`                                // 最后更新时间戳（毫秒）
 }
 
 func (BizConfig) TableName() string {
 	return "biz_configs"
 }
 
+// BizConfigDAO 是用于操作BizConfig数据库的DAO（数据访问对象）结构体。
 type BizConfigDAO struct {
-	db *gorm.DB
+	db *gorm.DB // 指向GORM数据库连接的指针
 }
 
+// NewBizConfigDAO 创建一个新的BizConfigDAO实例。
 func NewBizConfigDAO(db *gorm.DB) *BizConfigDAO {
 	return &BizConfigDAO{db: db}
 }
 
+// Insert 将一个新的业务配置记录插入数据库，并设置其创建和更新时间。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	bc: 要插入的BizConfig对象指针
+//
+// 返回值:
+//
+//	BizConfig: 插入成功的BizConfig对象
+//	error: 插入过程中发生的错误
 func (d *BizConfigDAO) Insert(ctx context.Context, bc *BizConfig) (BizConfig, error) {
 	now := time.Now().UnixMilli()
 	bc.Ctime = now
@@ -38,20 +52,45 @@ func (d *BizConfigDAO) Insert(ctx context.Context, bc *BizConfig) (BizConfig, er
 	return *bc, nil
 }
 
-// GetByID 根据ID查询
+// GetByID 根据ID查询业务配置。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	id: 要查询的配置ID
+//
+// 返回值:
+//
+//	BizConfig: 查询到的BizConfig对象
+//	error: 查询过程中发生的错误
 func (d *BizConfigDAO) GetByID(ctx context.Context, id int64) (BizConfig, error) {
 	var bc BizConfig
 	err := d.db.WithContext(ctx).Where("id = ?", id).First(&bc).Error
 	return bc, err
 }
 
-// Update 更新记录
+// Update 更新现有的业务配置记录。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	bc: 包含更新数据的BizConfig对象指针
+//
+// 返回值:
+//
+//	error: 更新过程中发生的错误
 func (d *BizConfigDAO) Update(ctx context.Context, bc *BizConfig) error {
 	bc.Utime = time.Now().UnixMilli()
 	return d.db.WithContext(ctx).Save(bc).Error
 }
 
-// Delete 删除记录
+// Delete 根据ID删除业务配置记录。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	id: 要删除的配置ID
+//
+// 返回值:
+//
+//	error: 删除过程中发生的错误
 func (d *BizConfigDAO) Delete(ctx context.Context, id string) error {
 	return d.db.WithContext(ctx).Where("id = ?", id).Delete(&BizConfig{}).Error
 }

--- a/internal/repository/dao/graph.go
+++ b/internal/repository/dao/graph.go
@@ -8,39 +8,45 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+// Node 结构体定义
+// 表示图中的一个节点
 type Node struct {
-	ID       int64  `gorm:"column:id;primaryKey;autoIncrement"`
-	Type     string `gorm:"column:type"`
-	GraphID  int64  `gorm:"column:graph_id;index"`
-	Status   string `gorm:"column:status"`
-	Metadata string `gorm:"column:metadata"`
-	Ctime    int64  `gorm:"column:ctime"`
-	Utime    int64  `gorm:"column:utime"`
+	ID       int64  `gorm:"column:id;primaryKey;autoIncrement"` // 节点的唯一标识符
+	Type     string `gorm:"column:type"`                        // 节点类型
+	GraphID  int64  `gorm:"column:graph_id;index"`              // 所属图的ID
+	Status   string `gorm:"column:status"`                      // 节点状态
+	Metadata string `gorm:"column:metadata"`                    // 节点元数据，存储为JSON格式字符串
+	Ctime    int64  `gorm:"column:ctime"`                       // 创建时间戳（毫秒）
+	Utime    int64  `gorm:"column:utime"`                       // 最后更新时间戳（毫秒）
 }
 
 func (Node) TableName() string {
 	return "nodes"
 }
 
+// Edge 结构体定义
+// 表示图中的一个边（连接）
 type Edge struct {
-	ID       int64  `gorm:"column:id;primaryKey;autoIncrement"`
-	GraphID  int64  `gorm:"column:graph_id;index"`
-	SourceID int64  `gorm:"column:source_id;index:idx_source_target"`
-	TargetID int64  `gorm:"column:target_id;index:idx_source_target"`
-	Metadata string `gorm:"column:metadata;"`
-	Ctime    int64  `gorm:"column:ctime"`
-	Utime    int64  `gorm:"column:utime"`
+	ID       int64  `gorm:"column:id;primaryKey;autoIncrement"`       // 边的唯一标识符
+	GraphID  int64  `gorm:"column:graph_id;index"`                    // 所属图的ID
+	SourceID int64  `gorm:"column:source_id;index:idx_source_target"` // 源节点ID
+	TargetID int64  `gorm:"column:target_id;index:idx_source_target"` // 目标节点ID
+	Metadata string `gorm:"column:metadata;"`                         // 边的元数据，存储为JSON格式字符串
+	Ctime    int64  `gorm:"column:ctime"`                             // 创建时间戳（毫秒）
+	Utime    int64  `gorm:"column:utime"`                             // 最后更新时间戳（毫秒）
 }
 
 func (Edge) TableName() string {
 	return "edges"
 }
 
+// Graph 结构体定义
+// 表示一个完整的图结构
 type Graph struct {
-	ID       int64  `gorm:"column:id;primaryKey;autoIncrement"`
-	Metadata string `gorm:"column:metadata"`
-	Ctime    int64  `gorm:"column:ctime"`
-	Utime    int64  `gorm:"column:utime"`
+	ID       int64  `gorm:"column:id;primaryKey;autoIncrement"` // 图的唯一标识符
+	Metadata string `gorm:"column:metadata"`                    // 图的元数据，存储为JSON格式字符串
+	Ctime    int64  `gorm:"column:ctime"`                       // 创建时间戳（毫秒）
+	Utime    int64  `gorm:"column:utime"`                       // 最后更新时间戳（毫秒）
 }
 
 func (Graph) TableName() string {

--- a/internal/repository/dao/init.go
+++ b/internal/repository/dao/init.go
@@ -2,6 +2,16 @@ package dao
 
 import "gorm.io/gorm"
 
+// InitTables 初始化数据库表结构
+// 参数:
+//
+//	db: 指向gorm.DB的数据库连接指针
+//
+// 返回值:
+//
+//	error: 初始化过程中发生的错误
+//
+// 注意：当前仅初始化BizConfig表，可根据需要扩展其他表
 func InitTables(db *gorm.DB) error {
 	return db.AutoMigrate(&BizConfig{})
 }

--- a/internal/repository/dao/prompt.go
+++ b/internal/repository/dao/prompt.go
@@ -11,10 +11,27 @@ type PromptDAO struct {
 	db *gorm.DB
 }
 
+// NewPromptDAO 创建一个新的 PromptDAO 实例。
+// 参数:
+//
+//	db: 指向 gorm.DB 的数据库连接指针
+//
+// 返回值:
+//
+//	*PromptDAO: 初始化后的 PromptDAO 结构体指针
 func NewPromptDAO(db *gorm.DB) *PromptDAO {
 	return &PromptDAO{db: db}
 }
 
+/*
+ * Create 在事务中创建提示及其初始版本。
+ * 参数:
+ *   ctx: 上下文对象用于控制请求生命周期
+ *   prompt: 要创建的提示基础信息
+ *   version: 与提示关联的初始版本信息
+ * 返回值:
+ *   error: 执行过程中发生的错误，如果成功则为nil
+ */
 func (p *PromptDAO) Create(ctx context.Context, prompt Prompt, version PromptVersion) error {
 	return p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		now := time.Now().UnixMilli()
@@ -29,6 +46,16 @@ func (p *PromptDAO) Create(ctx context.Context, prompt Prompt, version PromptVer
 	})
 }
 
+/*
+ * FindByID 根据ID查询完整提示信息（包含所有版本）。
+ * 参数:
+ *   ctx: 上下文对象用于控制请求生命周期
+ *   id: 要查询的提示ID
+ * 返回值:
+ *   Prompt: 查询到的提示信息
+ *   []PromptVersion: 关联的所有版本信息
+ *   error: 执行过程中发生的错误
+ */
 func (p *PromptDAO) FindByID(ctx context.Context, id int64) (Prompt, []PromptVersion, error) {
 	var res Prompt
 	err := p.db.WithContext(ctx).Where("id = ?", id).First(&res).Error
@@ -40,18 +67,42 @@ func (p *PromptDAO) FindByID(ctx context.Context, id int64) (Prompt, []PromptVer
 	return res, versions, err
 }
 
+/*
+ * UpdatePrompt 更新提示的基本信息。
+ * 参数:
+ *   ctx: 上下文对象用于控制请求生命周期
+ *   value: 包含更新数据的提示对象
+ * 返回值:
+ *   error: 执行过程中发生的错误
+ */
 func (p *PromptDAO) UpdatePrompt(ctx context.Context, value Prompt) error {
 	// 更新非零值
 	value.Utime = time.Now().UnixMilli()
 	return p.db.WithContext(ctx).Model(&Prompt{}).Where("id = ?", value.ID).Updates(value).Error
 }
 
+/*
+ * UpdateVersion 更新指定版本的信息。
+ * 参数:
+ *   ctx: 上下文对象用于控制请求生命周期
+ *   value: 包含更新数据的版本对象
+ * 返回值:
+ *   error: 执行过程中发生的错误
+ */
 func (p *PromptDAO) UpdateVersion(ctx context.Context, value PromptVersion) error {
 	// 更新非零值
 	value.Utime = time.Now().UnixMilli()
 	return p.db.WithContext(ctx).Model(&PromptVersion{}).Where("id = ?", value.ID).Updates(value).Error
 }
 
+/*
+ * Delete 在事务中软删除提示及其所有版本。
+ * 参数:
+ *   ctx: 上下文对象用于控制请求生命周期
+ *   id: 要删除的提示ID
+ * 返回值:
+ *   error: 执行过程中发生的错误
+ */
 func (p *PromptDAO) Delete(ctx context.Context, id int64) error {
 	return p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		now := time.Now().UnixMilli()
@@ -69,6 +120,14 @@ func (p *PromptDAO) Delete(ctx context.Context, id int64) error {
 	})
 }
 
+/*
+ * DeleteVersion 软删除指定版本。
+ * 参数:
+ *   ctx: 上下文对象用于控制请求生命周期
+ *   versionID: 要删除的版本ID
+ * 返回值:
+ *   error: 执行过程中发生的错误
+ */
 func (p *PromptDAO) DeleteVersion(ctx context.Context, versionID int64) error {
 	return p.db.WithContext(ctx).Model(&PromptVersion{}).Where("id = ?", versionID).Updates(map[string]any{
 		"status": 0,
@@ -76,6 +135,15 @@ func (p *PromptDAO) DeleteVersion(ctx context.Context, versionID int64) error {
 	}).Error
 }
 
+/*
+ * UpdateActiveVersion 更新提示的激活版本。
+ * 参数:
+ *   ctx: 上下文对象用于控制请求生命周期
+ *   versionID: 要激活的新版本ID
+ *   label: 新版本标签
+ * 返回值:
+ *   error: 执行过程中发生的错误
+ */
 func (p *PromptDAO) UpdateActiveVersion(ctx context.Context, versionID int64, label string) error {
 	var id int64
 	err := p.db.WithContext(ctx).Model(&PromptVersion{}).Where("id = ?", versionID).Select("prompt_id").First(&id).Error
@@ -99,6 +167,14 @@ func (p *PromptDAO) UpdateActiveVersion(ctx context.Context, versionID int64, la
 	})
 }
 
+/*
+ * InsertVersion 插入新的版本记录。
+ * 参数:
+ *   ctx: 上下文对象用于控制请求生命周期
+ *   version: 要插入的版本对象
+ * 返回值:
+ *   error: 执行过程中发生的错误
+ */
 func (p *PromptDAO) InsertVersion(ctx context.Context, version PromptVersion) error {
 	now := time.Now().UnixMilli()
 	version.Ctime = now
@@ -106,40 +182,53 @@ func (p *PromptDAO) InsertVersion(ctx context.Context, version PromptVersion) er
 	return p.db.WithContext(ctx).Create(&version).Error
 }
 
+/*
+ * GetByVersionID 根据版本ID查询版本详情。
+ * 参数:
+ *   ctx: 上下文对象用于控制请求生命周期
+ *   versionID: 要查询的版本ID
+ * 返回值:
+ *   PromptVersion: 查询到的版本信息
+ *   error: 执行过程中发生的错误
+ */
 func (p *PromptDAO) GetByVersionID(ctx context.Context, versionID int64) (PromptVersion, error) {
 	var res PromptVersion
 	err := p.db.WithContext(ctx).Model(&PromptVersion{}).Where("id = ?", versionID).First(&res).Error
 	return res, err
 }
 
+// Prompt 结构体定义
+// 表示一个提示模板的基本信息
 type Prompt struct {
-	ID            int64  `gorm:"column:id;primaryKey;autoIncrement"`
-	Name          string `gorm:"column:name"`
-	Owner         int64  `gorm:"column:owner;index:idx_owner_owner_type"`
-	OwnerType     string `gorm:"column:owner_type;type:ENUM('personal','organization');index:idx_owner_owner_type"`
-	ActiveVersion int64  `gorm:"column:active_version"`
-	Description   string `gorm:"column:description"`
-	Status        uint8  `gorm:"column:status;default:1"`
-	Ctime         int64  `gorm:"column:ctime"`
-	Utime         int64  `gorm:"column:utime"`
+	ID            int64  `gorm:"column:id;primaryKey;autoIncrement"`                                                // 提示的唯一标识符
+	Name          string `gorm:"column:name"`                                                                       // 提示名称
+	Owner         int64  `gorm:"column:owner;index:idx_owner_owner_type"`                                           // 所有者ID
+	OwnerType     string `gorm:"column:owner_type;type:ENUM('personal','organization');index:idx_owner_owner_type"` // 所有者类型：个人或组织
+	ActiveVersion int64  `gorm:"column:active_version"`                                                             // 当前激活的版本ID
+	Description   string `gorm:"column:description"`                                                                // 提示描述
+	Status        uint8  `gorm:"column:status;default:1"`                                                           // 状态：0表示删除，1表示有效
+	Ctime         int64  `gorm:"column:ctime"`                                                                      // 创建时间戳（毫秒）
+	Utime         int64  `gorm:"column:utime"`                                                                      // 最后更新时间戳（毫秒）
 }
 
 func (Prompt) TableName() string {
 	return "prompts"
 }
 
+// PromptVersion 结构体定义
+// 表示提示模板的具体版本信息
 type PromptVersion struct {
-	ID            int64   `gorm:"column:id;primaryKey;autoIncrement"`
-	PromptID      int64   `gorm:"column:prompt_id;index"`
-	Label         string  `gorm:"column:label"`
-	Content       string  `gorm:"column:content"`
-	SystemContent string  `gorm:"column:system_content"`
-	Temperature   float32 `gorm:"column:temperature"`
-	TopN          float32 `gorm:"column:top_n"`
-	MaxTokens     int     `gorm:"column:max_tokens"`
-	Status        uint8   `gorm:"column:status;default:1"`
-	Ctime         int64   `gorm:"column:ctime"`
-	Utime         int64   `gorm:"column:utime"`
+	ID            int64   `gorm:"column:id;primaryKey;autoIncrement"` // 版本ID
+	PromptID      int64   `gorm:"column:prompt_id;index"`             // 关联的提示ID
+	Label         string  `gorm:"column:label"`                       // 版本标签
+	Content       string  `gorm:"column:content"`                     // 主要内容
+	SystemContent string  `gorm:"column:system_content"`              // 系统消息内容
+	Temperature   float32 `gorm:"column:temperature"`                 // 模型温度参数
+	TopN          float32 `gorm:"column:top_n"`                       // Top N采样参数
+	MaxTokens     int     `gorm:"column:max_tokens"`                  // 最大生成token数
+	Status        uint8   `gorm:"column:status;default:1"`            // 状态：0表示删除，1表示有效
+	Ctime         int64   `gorm:"column:ctime"`                       // 创建时间戳（毫秒）
+	Utime         int64   `gorm:"column:utime"`                       // 最后更新时间戳（毫秒）
 }
 
 func (PromptVersion) TableName() string {

--- a/internal/repository/graph.go
+++ b/internal/repository/graph.go
@@ -9,14 +9,34 @@ import (
 	"github.com/ecodeclub/ekit/slice"
 )
 
+// NodeRepo 是图结构的仓库实现，负责在领域模型和数据访问层之间进行转换。
 type NodeRepo struct {
-	graph *dao.GraphDAO
+	graph *dao.GraphDAO // 数据访问对象，用于操作数据库
 }
 
+// NewGraphRepo 创建一个新的NodeRepo实例。
+// 参数:
+//
+//	graph: 数据访问对象实例
+//
+// 返回值:
+//
+//	*NodeRepo: 初始化后的NodeRepo实例
 func NewGraphRepo(graph *dao.GraphDAO) *NodeRepo {
 	return &NodeRepo{graph: graph}
 }
 
+// SaveGraph 保存图结构到数据库。
+// 如果图已经存在则更新它，否则创建新图。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	graph: 要保存的图结构
+//
+// 返回值:
+//
+//	int64: 保存后的图ID
+//	error: 执行过程中发生的错误
 func (n *NodeRepo) SaveGraph(ctx context.Context, graph domain.Graph) (int64, error) {
 	str, _ := graph.Metadata.AsString()
 
@@ -26,6 +46,17 @@ func (n *NodeRepo) SaveGraph(ctx context.Context, graph domain.Graph) (int64, er
 	})
 }
 
+// SaveNode 保存节点到数据库。
+// 如果节点已经存在则更新它，否则创建新节点。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	node: 要保存的节点信息
+//
+// 返回值:
+//
+//	int64: 保存后的节点ID
+//	error: 执行过程中发生的错误
 func (n *NodeRepo) SaveNode(ctx context.Context, node domain.Node) (int64, error) {
 	str, _ := node.Metadata.AsString()
 	return n.graph.SaveNode(ctx, dao.Node{
@@ -37,6 +68,17 @@ func (n *NodeRepo) SaveNode(ctx context.Context, node domain.Node) (int64, error
 	})
 }
 
+// SaveEdge 保存边（连接）到数据库。
+// 如果边已经存在则更新它，否则创建新边。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	edge: 要保存的边信息
+//
+// 返回值:
+//
+//	int64: 保存后的边ID
+//	error: 执行过程中发生的错误
 func (n *NodeRepo) SaveEdge(ctx context.Context, edge domain.Edge) (int64, error) {
 	str, _ := edge.Metadata.AsString()
 
@@ -49,18 +91,55 @@ func (n *NodeRepo) SaveEdge(ctx context.Context, edge domain.Edge) (int64, error
 	})
 }
 
+// DeleteGraph 根据ID删除图及其所有节点和边。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	id: 要删除的图ID
+//
+// 返回值:
+//
+//	error: 执行过程中发生的错误
 func (n *NodeRepo) DeleteGraph(ctx context.Context, id int64) error {
 	return n.graph.DeleteGraph(ctx, id)
 }
 
+// DeleteNode 根据ID删除节点。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	id: 要删除的节点ID
+//
+// 返回值:
+//
+//	error: 执行过程中发生的错误
 func (n *NodeRepo) DeleteNode(ctx context.Context, id int64) error {
 	return n.graph.DeleteNode(ctx, id)
 }
 
+// DeleteEdge 根据ID删除边。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	id: 要删除的边ID
+//
+// 返回值:
+//
+//	error: 执行过程中发生的错误
 func (n *NodeRepo) DeleteEdge(ctx context.Context, id int64) error {
 	return n.graph.DeleteEdge(ctx, id)
 }
 
+// GetGraph 根据ID获取完整的图结构（包括所有节点和边）。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	id: 要查询的图ID
+//
+// 返回值:
+//
+//	domain.Graph: 查询到的图结构
+//	error: 执行过程中发生的错误
 func (n *NodeRepo) GetGraph(ctx context.Context, id int64) (domain.Graph, error) {
 	graph, err := n.graph.GetGraph(ctx, id)
 	if err != nil {
@@ -77,6 +156,16 @@ func (n *NodeRepo) GetGraph(ctx context.Context, id int64) (domain.Graph, error)
 	return n.daoToDomain(graph, edges, nodes), nil
 }
 
+// daoToDomain 将DAO层的数据转换为领域模型的图结构。
+// 参数:
+//
+//	graph: DAO层的图结构
+//	edges: DAO层的边列表
+//	nodes: DAO层的节点列表
+//
+// 返回值:
+//
+//	domain.Graph: 领域模型的图结构
 func (n *NodeRepo) daoToDomain(graph dao.Graph, edges []dao.Edge, nodes []dao.Node) domain.Graph {
 	var plan domain.Graph
 	plan.ID = graph.ID

--- a/internal/repository/prompt.go
+++ b/internal/repository/prompt.go
@@ -7,14 +7,33 @@ import (
 	"time"
 )
 
+// PromptRepo 是提示模板的仓库实现，负责在领域模型和数据访问层之间进行转换。
 type PromptRepo struct {
-	dao *dao.PromptDAO
+	dao *dao.PromptDAO // 数据访问对象，用于操作数据库
 }
 
+// NewPromptRepo 创建一个新的PromptRepo实例。
+// 参数:
+//
+//	dao: 数据访问对象实例
+//
+// 返回值:
+//
+//	*PromptRepo: 初始化后的PromptRepo实例
 func NewPromptRepo(dao *dao.PromptDAO) *PromptRepo {
 	return &PromptRepo{dao: dao}
 }
 
+// Create 创建一个新的提示及其初始版本。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	prompt: 要创建的提示基础信息
+//	version: 与提示关联的初始版本信息
+//
+// 返回值:
+//
+//	error: 执行过程中发生的错误，如果成功则为nil
 func (p *PromptRepo) Create(ctx context.Context, prompt domain.Prompt, version domain.PromptVersion) error {
 	dPrompt := dao.Prompt{
 		Name:        prompt.Name,
@@ -32,6 +51,16 @@ func (p *PromptRepo) Create(ctx context.Context, prompt domain.Prompt, version d
 	return p.dao.Create(ctx, dPrompt, dVersion)
 }
 
+// Get 根据ID获取完整的提示信息（包括所有版本）。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	id: 要查询的提示ID
+//
+// 返回值:
+//
+//	domain.Prompt: 查询到的提示信息
+//	error: 执行过程中发生的错误
 func (p *PromptRepo) Get(ctx context.Context, id int64) (domain.Prompt, error) {
 	prompt, dVersions, err := p.dao.FindByID(ctx, id)
 	if err != nil {
@@ -65,14 +94,41 @@ func (p *PromptRepo) Get(ctx context.Context, id int64) (domain.Prompt, error) {
 	}, nil
 }
 
+// Delete 在事务中软删除提示及其所有版本。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	id: 要删除的提示ID
+//
+// 返回值:
+//
+//	error: 执行过程中发生的错误
 func (p *PromptRepo) Delete(ctx context.Context, id int64) error {
 	return p.dao.Delete(ctx, id)
 }
 
+// DeleteVersion 软删除指定版本。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	versionID: 要删除的版本ID
+//
+// 返回值:
+//
+//	error: 执行过程中发生的错误
 func (p *PromptRepo) DeleteVersion(ctx context.Context, versionID int64) error {
 	return p.dao.DeleteVersion(ctx, versionID)
 }
 
+// UpdateInfo 更新提示的基本信息（名称和描述）。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	value: 包含更新数据的提示对象
+//
+// 返回值:
+//
+//	error: 执行过程中发生的错误
 func (p *PromptRepo) UpdateInfo(ctx context.Context, value domain.Prompt) error {
 	return p.dao.UpdatePrompt(ctx, dao.Prompt{
 		ID:          value.ID,
@@ -81,6 +137,15 @@ func (p *PromptRepo) UpdateInfo(ctx context.Context, value domain.Prompt) error 
 	})
 }
 
+// UpdateVersion 更新指定版本的信息。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	value: 包含更新数据的版本对象
+//
+// 返回值:
+//
+//	error: 执行过程中发生的错误
 func (p *PromptRepo) UpdateVersion(ctx context.Context, value domain.PromptVersion) error {
 	return p.dao.UpdateVersion(ctx, dao.PromptVersion{
 		ID:            value.ID,
@@ -92,10 +157,30 @@ func (p *PromptRepo) UpdateVersion(ctx context.Context, value domain.PromptVersi
 	})
 }
 
+// UpdateActiveVersion 更新提示的激活版本。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	versionID: 要激活的新版本ID
+//	label: 新版本标签
+//
+// 返回值:
+//
+//	error: 执行过程中发生的错误
 func (p *PromptRepo) UpdateActiveVersion(ctx context.Context, versionID int64, label string) error {
 	return p.dao.UpdateActiveVersion(ctx, versionID, label)
 }
 
+// InsertVersion 插入新的版本记录。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	id: 提示ID
+//	version: 要插入的版本对象
+//
+// 返回值:
+//
+//	error: 执行过程中发生的错误
 func (p *PromptRepo) InsertVersion(ctx context.Context, id int64, version domain.PromptVersion) error {
 	return p.dao.InsertVersion(ctx, dao.PromptVersion{
 		PromptID:      id,
@@ -107,6 +192,16 @@ func (p *PromptRepo) InsertVersion(ctx context.Context, id int64, version domain
 	})
 }
 
+// GetByVersionID 根据版本ID查询版本详情。
+// 参数:
+//
+//	ctx: 上下文对象用于控制请求生命周期
+//	id: 要查询的版本ID
+//
+// 返回值:
+//
+//	domain.Prompt: 查询到的提示信息（仅包含请求的版本）
+//	error: 执行过程中发生的错误
 func (p *PromptRepo) GetByVersionID(ctx context.Context, id int64) (domain.Prompt, error) {
 	res, err := p.dao.GetByVersionID(ctx, id)
 	if err != nil {

--- a/internal/service/bizconfig.go
+++ b/internal/service/bizconfig.go
@@ -1,3 +1,6 @@
+// bizconfig.go 文件包含业务配置服务的接口定义和实现
+// 提供了创建、获取、更新和删除业务配置的功能
+
 package service
 
 import (
@@ -6,10 +9,30 @@ import (
 	"github.com/ecodeclub/ai-gateway-go/internal/repository"
 )
 
+// BizConfigService 定义了处理业务配置的基本方法
 type BizConfigService interface {
+	// Create 创建一个新的业务配置
+	// 参数 ctx 是上下文，用于控制请求的生命周期
+	// 参数 config 是 domain.BizConfig 类型，表示要创建的配置
+	// 返回值是创建后的 domain.BizConfig 对象和可能发生的错误
 	Create(ctx context.Context, config domain.BizConfig) (domain.BizConfig, error)
+
+	// GetByID 根据 ID 获取业务配置
+	// 参数 ctx 是上下文，用于控制请求的生命周期
+	// 参数 id 是 int64 类型，表示配置的 ID
+	// 返回值是 domain.BizConfig 对象和可能发生的错误
 	GetByID(ctx context.Context, id int64) (domain.BizConfig, error)
+
+	// Update 更新业务配置
+	// 参数 ctx 是上下文，用于控制请求的生命周期
+	// 参数 config 是 domain.BizConfig 类型，表示要更新的配置
+	// 返回值是可能发生的错误
 	Update(ctx context.Context, config domain.BizConfig) error
+
+	// Delete 根据 ID 删除业务配置
+	// 参数 ctx 是上下文，用于控制请求的生命周期
+	// 参数 id 是 string 类型，表示配置的 ID
+	// 返回值是可能发生的错误
 	Delete(ctx context.Context, id string) error
 }
 
@@ -17,12 +40,19 @@ type bizConfigService struct {
 	repo *repository.BizConfigRepository
 }
 
+// NewBizConfigService 创建一个新的 BizConfigService 实例
+// 参数 repo 是 *repository.BizConfigRepository 类型，表示数据访问层
+// 返回值是 BizConfigService 接口类型
 func NewBizConfigService(repo *repository.BizConfigRepository) BizConfigService {
 	return &bizConfigService{
 		repo: repo,
 	}
 }
 
+// Create 创建一个新的业务配置
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 req 是 domain.BizConfig 类型，表示客户端的请求
+// 返回值是创建后的 domain.BizConfig 对象和可能发生的错误
 func (s *bizConfigService) Create(ctx context.Context, req domain.BizConfig) (domain.BizConfig, error) {
 	config := domain.BizConfig{
 		OwnerID:   req.OwnerID,
@@ -38,14 +68,26 @@ func (s *bizConfigService) Create(ctx context.Context, req domain.BizConfig) (do
 	return created, nil
 }
 
+// GetByID 根据 ID 获取业务配置
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 id 是 int64 类型，表示配置的 ID
+// 返回值是 domain.BizConfig 对象和可能发生的错误
 func (s *bizConfigService) GetByID(ctx context.Context, id int64) (domain.BizConfig, error) {
 	return s.repo.GetByID(ctx, id)
 }
 
+// Update 更新业务配置
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 config 是 domain.BizConfig 类型，表示要更新的配置
+// 返回值是可能发生的错误
 func (s *bizConfigService) Update(ctx context.Context, config domain.BizConfig) error {
 	return s.repo.Update(ctx, config)
 }
 
+// Delete 根据 ID 删除业务配置
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 id 是 string 类型，表示配置的 ID
+// 返回值是可能发生的错误
 func (s *bizConfigService) Delete(ctx context.Context, id string) error {
 	return s.repo.Delete(ctx, id)
 }

--- a/internal/service/graph.go
+++ b/internal/service/graph.go
@@ -7,38 +7,70 @@ import (
 	"github.com/ecodeclub/ai-gateway-go/internal/repository"
 )
 
+// NodeService 是一个结构体，包含一个 NodeRepo 的指针
 type NodeService struct {
 	repo *repository.NodeRepo
 }
 
+// NewGraphService 创建一个新的 NodeService 实例
+// 参数 repo 是 *repository.NodeRepo 类型，表示数据访问层
+// 返回值是 *NodeService 类型
 func NewGraphService(repo *repository.NodeRepo) *NodeService {
 	return &NodeService{repo: repo}
 }
 
+// GetGraph 根据 ID 获取图
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 id 是 int64 类型，表示图的 ID
+// 返回值是 domain.Graph 对象和可能发生的错误
 func (svc *NodeService) GetGraph(ctx context.Context, id int64) (domain.Graph, error) {
 	return svc.repo.GetGraph(ctx, id)
 }
 
+// SaveGraph 保存图
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 graph 是 domain.Graph 类型，表示要保存的图
+// 返回值是保存后的 ID 和可能发生的错误
 func (svc *NodeService) SaveGraph(ctx context.Context, graph domain.Graph) (int64, error) {
 	return svc.repo.SaveGraph(ctx, graph)
 }
 
+// SaveNode 保存节点
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 step 是 domain.Node 类型，表示要保存的节点
+// 返回值是保存后的 ID 和可能发生的错误
 func (svc *NodeService) SaveNode(ctx context.Context, step domain.Node) (int64, error) {
 	return svc.repo.SaveNode(ctx, step)
 }
 
+// SaveEdge 保存边
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 edge 是 domain.Edge 类型，表示要保存的边
+// 返回值是保存后的 ID 和可能发生的错误
 func (svc *NodeService) SaveEdge(ctx context.Context, edge domain.Edge) (int64, error) {
 	return svc.repo.SaveEdge(ctx, edge)
 }
 
+// DeleteEdge 删除边
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 id 是 int64 类型，表示要删除的边的 ID
+// 返回值是可能发生的错误
 func (svc *NodeService) DeleteEdge(ctx context.Context, id int64) error {
 	return svc.repo.DeleteEdge(ctx, id)
 }
 
+// DeleteNode 删除节点
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 id 是 int64 类型，表示要删除的节点的 ID
+// 返回值是可能发生的错误
 func (svc *NodeService) DeleteNode(ctx context.Context, id int64) error {
 	return svc.repo.DeleteNode(ctx, id)
 }
 
+// DeleteGraph 删除图
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 id 是 int64 类型，表示要删除的图的 ID
+// 返回值是可能发生的错误
 func (svc *NodeService) DeleteGraph(ctx context.Context, id int64) error {
 	return svc.repo.DeleteGraph(ctx, id)
 }

--- a/internal/service/llm/llm.go
+++ b/internal/service/llm/llm.go
@@ -5,7 +5,17 @@ import (
 	"github.com/ecodeclub/ai-gateway-go/internal/domain"
 )
 
+// LLMHandler 是一个接口，定义了处理 LLM 请求的基本方法
 type LLMHandler interface {
+	// StreamHandle 处理流式 LLM 请求
+	// 参数 ctx 是上下文，用于控制请求的生命周期
+	// 参数 req 是 domain.LLMRequest 类型，表示客户端的请求
+	// 返回值是一个 channel，用于返回 stream 事件，以及可能发生的错误
 	StreamHandle(ctx context.Context, req domain.LLMRequest) (chan domain.StreamEvent, error)
+
+	// Handle 处理普通的 LLM 请求
+	// 参数 ctx 是上下文，用于控制请求的生命周期
+	// 参数 req 是 domain.LLMRequest 类型，表示客户端的请求
+	// 返回值是 domain.LLMResponse 类型，表示处理结果，以及可能发生的错误
 	Handle(ctx context.Context, req domain.LLMRequest) (domain.LLMResponse, error)
 }

--- a/internal/service/llm/platform/deepseek/deepseek.go
+++ b/internal/service/llm/platform/deepseek/deepseek.go
@@ -9,14 +9,22 @@ import (
 	"time"
 )
 
+// Handler 是一个结构体，包含一个 deepseek.Client 的指针
 type Handler struct {
 	client *deepseek.Client
 }
 
+// NewHandler 创建一个新的 Handler 实例
+// 参数 client 是 *deepseek.Client 类型，用于与 DeepSeek API 通信
+// 返回值是 *Handler 类型
 func NewHandler(client *deepseek.Client) *Handler {
 	return &Handler{client: client}
 }
 
+// Handle 处理普通的 LLM 请求
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 req 是 domain.LLMRequest 类型，表示客户端的请求
+// 返回值是 domain.LLMResponse 类型，表示处理结果，以及可能发生的错误
 func (h *Handler) Handle(ctx context.Context, req domain.LLMRequest) (domain.LLMResponse, error) {
 	request := &deepseek.ChatCompletionRequest{
 		Model: deepseek.DeepSeekChat,
@@ -34,6 +42,10 @@ func (h *Handler) Handle(ctx context.Context, req domain.LLMRequest) (domain.LLM
 	return domain.LLMResponse{Content: response.Choices[0].Message.Content}, nil
 }
 
+// StreamHandle 处理流式 LLM 请求
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 req 是 domain.LLMRequest 类型，表示客户端的请求
+// 返回值是一个 channel，用于返回 stream 事件，以及可能发生的错误
 func (h *Handler) StreamHandle(ctx context.Context, req domain.LLMRequest) (chan domain.StreamEvent, error) {
 	request := deepseek.StreamChatCompletionRequest{
 		Model: deepseek.DeepSeekChat,
@@ -67,6 +79,9 @@ func (h *Handler) StreamHandle(ctx context.Context, req domain.LLMRequest) (chan
 	return events, nil
 }
 
+// recv 方法负责接收并处理来自 DeepSeek 流式响应的数据
+// 参数 eventCh 是用于发送事件的 channel
+// 参数 stream 是 deepseek.ChatCompletionStream 类型，表示 DeepSeek 的流式响应
 func (h *Handler) recv(eventCh chan domain.StreamEvent, stream deepseek.ChatCompletionStream) {
 	for {
 		chunk, err := stream.Recv()

--- a/internal/service/prompt.go
+++ b/internal/service/prompt.go
@@ -6,42 +6,80 @@ import (
 	"github.com/ecodeclub/ai-gateway-go/internal/repository"
 )
 
+// PromptService 是一个结构体，包含一个 PromptRepo 的指针
 type PromptService struct {
 	repo *repository.PromptRepo
 }
 
+// NewPromptService 创建一个新的 PromptService 实例
+// 参数 repo 是 *repository.PromptRepo 类型，表示数据访问层
+// 返回值是 *PromptService 类型
 func NewPromptService(repo *repository.PromptRepo) *PromptService {
 	return &PromptService{repo: repo}
 }
 
+// Add 添加提示信息
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 prompt 是 domain.Prompt 类型，表示要添加的提示
+// 参数 version 是 domain.PromptVersion 类型，表示提示的版本
+// 返回值是可能发生的错误
 func (s *PromptService) Add(ctx context.Context, prompt domain.Prompt, version domain.PromptVersion) error {
 	return s.repo.Create(ctx, prompt, version)
 }
 
+// Get 根据 ID 获取提示信息
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 id 是 int64 类型，表示提示的 ID
+// 返回值是 domain.Prompt 对象和可能发生的错误
 func (s *PromptService) Get(ctx context.Context, id int64) (domain.Prompt, error) {
 	return s.repo.Get(ctx, id)
 }
 
+// Delete 根据 ID 删除提示信息
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 id 是 int64 类型，表示要删除的提示的 ID
+// 返回值是可能发生的错误
 func (s *PromptService) Delete(ctx context.Context, id int64) error {
 	return s.repo.Delete(ctx, id)
 }
 
+// DeleteVersion 删除提示版本
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 versionID 是 int64 类型，表示要删除的提示版本的 ID
+// 返回值是可能发生的错误
 func (s *PromptService) DeleteVersion(ctx context.Context, versionID int64) error {
 	return s.repo.DeleteVersion(ctx, versionID)
 }
 
+// UpdateInfo 更新提示信息
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 prompt 是 domain.Prompt 类型，表示要更新的提示信息
+// 返回值是可能发生的错误
 func (s *PromptService) UpdateInfo(ctx context.Context, prompt domain.Prompt) error {
 	return s.repo.UpdateInfo(ctx, prompt)
 }
 
+// UpdateVersion 更新提示版本
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 version 是 domain.PromptVersion 类型，表示要更新的提示版本信息
+// 返回值是可能发生的错误
 func (s *PromptService) UpdateVersion(ctx context.Context, version domain.PromptVersion) error {
 	return s.repo.UpdateVersion(ctx, version)
 }
 
+// Publish 发布提示版本
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 versionID 是 int64 类型，表示要发布的提示版本的 ID
+// 参数 label 是 string 类型，表示发布的标签
+// 返回值是可能发生的错误
 func (s *PromptService) Publish(ctx context.Context, versionID int64, label string) error {
 	return s.repo.UpdateActiveVersion(ctx, versionID, label)
 }
 
+// Fork 分叉提示版本
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 versionID 是 int64 类型，表示要分叉的提示版本的 ID
+// 返回值是可能发生的错误
 func (s *PromptService) Fork(ctx context.Context, versionID int64) error {
 	prompt, err := s.repo.GetByVersionID(ctx, versionID)
 	if err != nil {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -6,18 +6,30 @@ import (
 	"github.com/ecodeclub/ai-gateway-go/internal/service/llm"
 )
 
+// AIService 是一个结构体，包含一个 LLMHandler 的指针
 type AIService struct {
 	handler llm.LLMHandler
 }
 
+// NewAIService 创建一个新的 AIService 实例
+// 参数 handler 是 llm.LLMHandler 类型，表示处理 LLM 请求的处理器
+// 返回值是 *AIService 类型
 func NewAIService(handler llm.LLMHandler) *AIService {
 	return &AIService{handler: handler}
 }
 
+// Stream 处理流式请求
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 req 是 domain.LLMRequest 类型，表示客户端的请求
+// 返回值是一个 channel，用于返回 stream 事件，以及可能发生的错误
 func (svc *AIService) Stream(ctx context.Context, req domain.LLMRequest) (chan domain.StreamEvent, error) {
 	return svc.handler.StreamHandle(ctx, req)
 }
 
+// Invoke 处理普通请求
+// 参数 ctx 是上下文，用于控制请求的生命周期
+// 参数 req 是 domain.LLMRequest 类型，表示客户端的请求
+// 返回值是 domain.LLMResponse 类型，表示处理结果，以及可能发生的错误
 func (svc *AIService) Invoke(ctx context.Context, req domain.LLMRequest) (domain.LLMResponse, error) {
 	return svc.handler.Handle(ctx, req)
 }

--- a/internal/test/graph_test.go
+++ b/internal/test/graph_test.go
@@ -23,16 +23,20 @@ import (
 	"gorm.io/gorm"
 )
 
+// GraphTestSuite 是一个测试套件，用于测试图相关的所有操作
+// 包括节点、边、图的保存、删除、查询等业务逻辑
 type GraphTestSuite struct {
 	suite.Suite
 	db     *gorm.DB
 	server *gin.Engine
 }
 
+// TestNode 运行关于节点操作的测试用例
 func TestNode(t *testing.T) {
 	suite.Run(t, new(GraphTestSuite))
 }
 
+// SetupSuite 初始化测试环境，配置数据库连接和表结构
 func (n *GraphTestSuite) SetupSuite() {
 	dbConfig := config.NewConfig(
 		config.WithDBName("ai_gateway_platform"),
@@ -56,6 +60,7 @@ func (n *GraphTestSuite) SetupSuite() {
 	n.server = server
 }
 
+// TearDownTest 每个测试用例执行后清理数据
 func (n *GraphTestSuite) TearDownTest() {
 	err := n.db.Exec("TRUNCATE TABLE edges").Error
 	require.NoError(n.T(), err)
@@ -65,6 +70,7 @@ func (n *GraphTestSuite) TearDownTest() {
 	require.NoError(n.T(), err)
 }
 
+// TestSaveNode 测试节点的保存功能（新增和更新）
 func (n *GraphTestSuite) TestSaveNode() {
 	t := n.T()
 
@@ -141,6 +147,7 @@ func (n *GraphTestSuite) TestSaveNode() {
 	}
 }
 
+// TestSaveEdge 测试边的保存功能（新增和更新）
 func (n *GraphTestSuite) TestSaveEdge() {
 	t := n.T()
 
@@ -222,6 +229,7 @@ func (n *GraphTestSuite) TestSaveEdge() {
 	}
 }
 
+// TestGetGraph 测试获取图信息的功能
 func (n *GraphTestSuite) TestGetGraph() {
 	t := n.T()
 
@@ -274,6 +282,7 @@ func (n *GraphTestSuite) TestGetGraph() {
 	}
 }
 
+// TestDeleteNode 测试删除节点的功能
 func (n *GraphTestSuite) TestDeleteNode() {
 	t := n.T()
 	ctrl := gomock.NewController(t)
@@ -320,6 +329,7 @@ func (n *GraphTestSuite) TestDeleteNode() {
 	}
 }
 
+// TestDeleteEdge 测试删除边的功能
 func (n *GraphTestSuite) TestDeleteEdge() {
 	t := n.T()
 	ctrl := gomock.NewController(t)

--- a/internal/test/prompt_test.go
+++ b/internal/test/prompt_test.go
@@ -23,16 +23,20 @@ import (
 	"gorm.io/gorm"
 )
 
+// PromptTestSuite 是一个测试套件，用于测试提示相关的所有操作
+// 包括提示的增删改查、版本管理、发布、删除版本等业务逻辑
 type PromptTestSuite struct {
 	suite.Suite
 	db     *gorm.DB
 	server *gin.Engine
 }
 
+// TestPrompt 运行关于提示操作的测试用例
 func TestPrompt(t *testing.T) {
 	suite.Run(t, new(PromptTestSuite))
 }
 
+// SetupSuite 初始化测试环境，配置数据库连接和表结构
 func (s *PromptTestSuite) SetupSuite() {
 	db, err := gorm.Open(mysql.Open("root:root@tcp(127.0.0.1:13316)/ai_gateway_go?charset=utf8mb4&parseTime=True&loc=Local&timeout=10s"))
 	require.NoError(s.T(), err)
@@ -48,6 +52,7 @@ func (s *PromptTestSuite) SetupSuite() {
 	s.server = server
 }
 
+// TearDownTest 每个测试用例执行后清理数据
 func (s *PromptTestSuite) TearDownTest() {
 	err := s.db.Exec("TRUNCATE TABLE prompts").Error
 	require.NoError(s.T(), err)
@@ -55,6 +60,7 @@ func (s *PromptTestSuite) TearDownTest() {
 	require.NoError(s.T(), err)
 }
 
+// TestAdd 测试新增提示及其初始版本的功能
 func (s *PromptTestSuite) TestAdd() {
 	ctrl := gomock.NewController(s.T())
 	defer ctrl.Finish()
@@ -134,6 +140,7 @@ func (s *PromptTestSuite) TestAdd() {
 	}
 }
 
+// TestGet 测试获取提示信息的功能
 func (s *PromptTestSuite) TestGet() {
 	ctrl := gomock.NewController(s.T())
 	defer ctrl.Finish()
@@ -221,6 +228,7 @@ func (s *PromptTestSuite) TestGet() {
 	}
 }
 
+// TestUpdatePrompt 测试更新提示基本信息的功能
 func (s *PromptTestSuite) TestUpdatePrompt() {
 	ctrl := gomock.NewController(s.T())
 	defer ctrl.Finish()
@@ -283,6 +291,7 @@ func (s *PromptTestSuite) TestUpdatePrompt() {
 	}
 }
 
+// TestUpdateVersion 测试更新提示版本信息的功能
 func (s *PromptTestSuite) TestUpdateVersion() {
 	ctrl := gomock.NewController(s.T())
 	defer ctrl.Finish()
@@ -347,6 +356,7 @@ func (s *PromptTestSuite) TestUpdateVersion() {
 	}
 }
 
+// TestDelete 测试删除整个提示（软删除）的功能
 func (s *PromptTestSuite) TestDelete() {
 	ctrl := gomock.NewController(s.T())
 	defer ctrl.Finish()
@@ -420,6 +430,7 @@ func (s *PromptTestSuite) TestDelete() {
 	}
 }
 
+// TestDeleteVersion 测试删除特定提示版本的功能
 func (s *PromptTestSuite) TestDeleteVersion() {
 	ctrl := gomock.NewController(s.T())
 	defer ctrl.Finish()
@@ -493,6 +504,7 @@ func (s *PromptTestSuite) TestDeleteVersion() {
 	}
 }
 
+// TestPublish 测试发布特定提示版本的功能
 func (s *PromptTestSuite) TestPublish() {
 	ctrl := gomock.NewController(s.T())
 	defer ctrl.Finish()
@@ -568,6 +580,7 @@ func (s *PromptTestSuite) TestPublish() {
 	}
 }
 
+// TestFork 测试复制（fork）提示版本的功能
 func (s *PromptTestSuite) TestFork() {
 	ctrl := gomock.NewController(s.T())
 	defer ctrl.Finish()
@@ -652,6 +665,8 @@ func (s *PromptTestSuite) TestFork() {
 	}
 }
 
+// Result 定义了统一的返回结果格式
+// 用于测试中解析 HTTP 响应结果
 type Result[T any] struct {
 	Code int    `json:"code"`
 	Msg  string `json:"msg"`

--- a/internal/test/server_test.go
+++ b/internal/test/server_test.go
@@ -14,14 +14,19 @@ import (
 	"testing"
 )
 
+// ServerTestSuite 是一个测试套件，用于测试服务器端流式处理和调用功能
+// 包含了流式事件和普通调用的测试用例
 type ServerTestSuite struct {
 	suite.Suite
 }
 
+// TestServer 运行关于服务器端流式处理和调用的测试用例
 func TestServer(t *testing.T) {
 	suite.Run(t, &ServerTestSuite{})
 }
 
+// TestStream 测试流式处理功能
+// 验证服务器能否正确处理并返回多个流式事件
 func (s *ServerTestSuite) TestStream() {
 	t := s.T()
 
@@ -63,6 +68,8 @@ func (s *ServerTestSuite) TestStream() {
 	}
 }
 
+// TestInvoke 测试普通调用功能
+// 验证服务器能否正确处理单次请求并返回结果
 func (s *ServerTestSuite) TestInvoke() {
 	t := s.T()
 

--- a/internal/web/bizconfig.go
+++ b/internal/web/bizconfig.go
@@ -11,14 +11,18 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// BizConfigHandler 处理与业务配置相关的 HTTP 请求
+// 提供创建、获取、更新和删除业务配置的功能
 type BizConfigHandler struct {
-	svc service.BizConfigService
+	svc service.BizConfigService // 业务逻辑层接口
 }
 
+// NewBizConfigHandler 创建一个新的 BizConfigHandler 实例
 func NewBizConfigHandler(svc service.BizConfigService) *BizConfigHandler {
 	return &BizConfigHandler{svc: svc}
 }
 
+// RegisterRoutes 注册业务配置相关的路由
 func (h *BizConfigHandler) RegisterRoutes(server *gin.Engine) {
 	bg := server.Group("/api/v1/biz-configs")
 
@@ -28,6 +32,7 @@ func (h *BizConfigHandler) RegisterRoutes(server *gin.Engine) {
 	bg.POST("/delete", ginx.BS[DeleteBizConfigReq](h.DeleteBizConfig))
 }
 
+// CreateBizConfigReq 定义创建业务配置的请求结构体
 type CreateBizConfigReq struct {
 	ID        int64  `json:"id"`
 	OwnerId   int64  `json:"owner_id"`
@@ -35,6 +40,7 @@ type CreateBizConfigReq struct {
 	Config    string `json:"config"`
 }
 
+// CreateBizConfig 处理创建业务配置的 HTTP 请求
 func (h *BizConfigHandler) CreateBizConfig(ctx *ginx.Context, req CreateBizConfigReq, sess session.Session) (ginx.Result, error) {
 	config := domain.BizConfig{
 		ID:        req.ID,
@@ -57,10 +63,12 @@ func (h *BizConfigHandler) CreateBizConfig(ctx *ginx.Context, req CreateBizConfi
 	}, nil
 }
 
+// GetBizConfigReq 定义获取业务配置的请求结构体
 type GetBizConfigReq struct {
 	ID int64 `json:"id"`
 }
 
+// GetBizConfig 处理获取业务配置的 HTTP 请求
 func (h *BizConfigHandler) GetBizConfig(ctx *ginx.Context, req GetBizConfigReq, sess session.Session) (ginx.Result, error) {
 	config, err := h.svc.GetByID(ctx.Request.Context(), req.ID)
 	if err == errs.ErrBizConfigNotFound {
@@ -76,6 +84,7 @@ func (h *BizConfigHandler) GetBizConfig(ctx *ginx.Context, req GetBizConfigReq, 
 	}, nil
 }
 
+// UpdateBizConfigReq 定义更新业务配置的请求结构体
 type UpdateBizConfigReq struct {
 	ID        int64  `json:"id"`
 	OwnerId   int64  `json:"owner_id"`
@@ -83,6 +92,7 @@ type UpdateBizConfigReq struct {
 	Config    string `json:"config"`
 }
 
+// UpdateBizConfig 处理更新业务配置的 HTTP 请求
 func (h *BizConfigHandler) UpdateBizConfig(ctx *ginx.Context, req UpdateBizConfigReq, sess session.Session) (ginx.Result, error) {
 	existing, err := h.svc.GetByID(ctx.Request.Context(), req.ID)
 	if err == errs.ErrBizConfigNotFound {
@@ -112,10 +122,12 @@ func (h *BizConfigHandler) UpdateBizConfig(ctx *ginx.Context, req UpdateBizConfi
 	}, nil
 }
 
+// DeleteBizConfigReq 定义删除业务配置的请求结构体
 type DeleteBizConfigReq struct {
 	ID int64 `json:"id"`
 }
 
+// DeleteBizConfig 处理删除业务配置的 HTTP 请求
 func (h *BizConfigHandler) DeleteBizConfig(ctx *ginx.Context, req DeleteBizConfigReq, sess session.Session) (ginx.Result, error) {
 	idStr := strconv.FormatInt(req.ID, 10)
 	if err := h.svc.Delete(ctx.Request.Context(), idStr); err != nil {
@@ -129,6 +141,7 @@ func (h *BizConfigHandler) DeleteBizConfig(ctx *ginx.Context, req DeleteBizConfi
 	}, nil
 }
 
+// toResponse 将领域模型转换为响应格式
 func (h *BizConfigHandler) toResponse(config domain.BizConfig) map[string]any {
 	return map[string]any{
 		"id":         config.ID,

--- a/internal/web/bizconfig_test.go
+++ b/internal/web/bizconfig_test.go
@@ -17,6 +17,8 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
+// fakeAuthMiddleware 创建一个假的身份验证中间件
+// 用于在测试中模拟 JWT 认证流程
 func fakeAuthMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// 获取JWT Bearer令牌
@@ -30,6 +32,8 @@ func fakeAuthMiddleware() gin.HandlerFunc {
 	}
 }
 
+// generateJWT 生成一个用于测试的 JWT 令牌
+// secret 是签名密钥
 func generateJWT(secret string) (string, error) {
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"iat": time.Now().Unix(),
@@ -39,6 +43,8 @@ func generateJWT(secret string) (string, error) {
 	return token.SignedString([]byte(secret))
 }
 
+// TestBizConfigHandler_Create 是针对业务配置创建功能的测试用例
+// 检查创建业务配置时的正常行为以及返回结果是否符合预期
 func TestBizConfigHandler_Create(t *testing.T) {
 	const createUrl = "/api/v1/biz-configs/create"
 	secret := "VGhpcyBpcyBhIHNlY3JldCB0aGF0IG5vYm9keSBjYW4gZ3Vlc3M=" // 你的 Secret

--- a/internal/web/graph.go
+++ b/internal/web/graph.go
@@ -11,14 +11,18 @@ import (
 	"go.uber.org/zap"
 )
 
+// GraphHandler 处理与图相关的 HTTP 请求
+// 提供保存、删除、查询图信息的功能
 type GraphHandler struct {
-	svc *service.NodeService
+	svc *service.NodeService // 图相关业务逻辑接口
 }
 
+// NewGraphHandler 创建一个新的 GraphHandler 实例
 func NewGraphHandler(nodeSvc *service.NodeService) *GraphHandler {
 	return &GraphHandler{svc: nodeSvc}
 }
 
+// PrivateRoutes 注册私有路由（需要身份验证）
 func (h *GraphHandler) PrivateRoutes(engine *gin.Engine) {
 	graph := engine.Group("/graph")
 	graph.POST("/save", ginx.BS[SaveGraphReq](h.SaveGraph))
@@ -34,10 +38,12 @@ func (h *GraphHandler) PrivateRoutes(engine *gin.Engine) {
 	edge.POST("/delete", ginx.BS[DeleteReq](h.DeleteEdge))
 }
 
+// PublicRoutes 注册公共路由（不需要身份验证）
 func (h *GraphHandler) PublicRoutes(engine *gin.Engine) {
 
 }
 
+// GetGraph 处理获取图信息的 HTTP 请求
 func (h *GraphHandler) GetGraph(ctx *ginx.Context, req GetReq, sess session.Session) (ginx.Result, error) {
 	graph, err := h.svc.GetGraph(ctx, req.ID)
 	if err != nil {
@@ -47,6 +53,7 @@ func (h *GraphHandler) GetGraph(ctx *ginx.Context, req GetReq, sess session.Sess
 	return ginx.Result{Msg: "OK", Data: newGetNodeVO(graph)}, err
 }
 
+// SaveGraph 处理保存图信息的 HTTP 请求
 func (h *GraphHandler) SaveGraph(ctx *ginx.Context, req SaveGraphReq, sess session.Session) (ginx.Result, error) {
 	graph := domain.Graph{
 		ID: req.ID,
@@ -61,6 +68,7 @@ func (h *GraphHandler) SaveGraph(ctx *ginx.Context, req SaveGraphReq, sess sessi
 	return ginx.Result{Msg: "OK", Data: id}, nil
 }
 
+// SaveNode 处理保存节点信息的 HTTP 请求
 func (h *GraphHandler) SaveNode(ctx *ginx.Context, req Node, sess session.Session) (ginx.Result, error) {
 	node := domain.Node{
 		ID:       req.ID,
@@ -78,6 +86,7 @@ func (h *GraphHandler) SaveNode(ctx *ginx.Context, req Node, sess session.Sessio
 	return ginx.Result{Data: id}, nil
 }
 
+// SaveEdge 处理保存边信息的 HTTP 请求
 func (h *GraphHandler) SaveEdge(ctx *ginx.Context, req Edge, sess session.Session) (ginx.Result, error) {
 	edge := domain.Edge{
 		ID:       req.ID,
@@ -98,6 +107,7 @@ func (h *GraphHandler) SaveEdge(ctx *ginx.Context, req Edge, sess session.Sessio
 	}, nil
 }
 
+// DeleteNode 处理删除节点的 HTTP 请求
 func (h *GraphHandler) DeleteNode(ctx *ginx.Context, req DeleteReq, sess session.Session) (ginx.Result, error) {
 	id := req.ID
 
@@ -111,6 +121,7 @@ func (h *GraphHandler) DeleteNode(ctx *ginx.Context, req DeleteReq, sess session
 	}, nil
 }
 
+// DeleteEdge 处理删除边的 HTTP 请求
 func (h *GraphHandler) DeleteEdge(ctx *ginx.Context, req DeleteReq, sess session.Session) (ginx.Result, error) {
 	id := req.ID
 	err := h.svc.DeleteEdge(ctx, id)
@@ -123,6 +134,7 @@ func (h *GraphHandler) DeleteEdge(ctx *ginx.Context, req DeleteReq, sess session
 	}, nil
 }
 
+// DeleteGraph 处理删除整个图的 HTTP 请求
 func (h *GraphHandler) DeleteGraph(ctx *ginx.Context, req DeleteReq, sess session.Session) (ginx.Result, error) {
 	id := req.ID
 	err := h.svc.DeleteGraph(ctx, id)

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -8,14 +8,18 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// Handler 处理与提示相关的 HTTP 请求
+// 提供添加、获取、更新、删除提示及其版本管理的功能
 type Handler struct {
-	svc *service.PromptService
+	svc *service.PromptService // 提示相关业务逻辑接口
 }
 
+// NewHandler 创建一个新的 Handler 实例
 func NewHandler(svc *service.PromptService) *Handler {
 	return &Handler{svc: svc}
 }
 
+// PrivateRoutes 注册私有路由（需要身份验证）
 func (h *Handler) PrivateRoutes(server *gin.Engine) {
 	prompt := server.Group("/prompt")
 	prompt.POST("/add", ginx.BS(h.Add))
@@ -28,8 +32,10 @@ func (h *Handler) PrivateRoutes(server *gin.Engine) {
 	prompt.POST("/fork", ginx.B(h.Fork))
 }
 
+// PublicRoutes 注册公共路由（不需要身份验证）
 func (h *Handler) PublicRoutes(server *gin.Engine) {}
 
+// Add 处理添加新提示及其初始版本的 HTTP 请求
 func (h *Handler) Add(ctx *ginx.Context, req AddReq, sess session.Session) (ginx.Result, error) {
 	uid := sess.Claims().Uid
 	// 这里我假设 owner_type 也存储在 jwt token 里
@@ -59,6 +65,7 @@ func (h *Handler) Add(ctx *ginx.Context, req AddReq, sess session.Session) (ginx
 	}, nil
 }
 
+// Get 处理获取提示信息的 HTTP 请求
 func (h *Handler) Get(ctx *ginx.Context) (ginx.Result, error) {
 	id, err := ctx.Param("id").AsInt64()
 	if err != nil {
@@ -73,7 +80,7 @@ func (h *Handler) Get(ctx *ginx.Context) (ginx.Result, error) {
 	}, nil
 }
 
-// Delete 删除整个 prompt
+// Delete 处理删除整个提示（软删除）的 HTTP 请求
 func (h *Handler) Delete(ctx *ginx.Context, req DeleteReq) (ginx.Result, error) {
 	err := h.svc.Delete(ctx, req.ID)
 	if err != nil {
@@ -84,6 +91,7 @@ func (h *Handler) Delete(ctx *ginx.Context, req DeleteReq) (ginx.Result, error) 
 	}, nil
 }
 
+// DeleteVersion 处理删除特定提示版本的 HTTP 请求
 func (h *Handler) DeleteVersion(ctx *ginx.Context, req DeleteVersionReq) (ginx.Result, error) {
 	err := h.svc.DeleteVersion(ctx, req.VersionID)
 	if err != nil {
@@ -94,7 +102,7 @@ func (h *Handler) DeleteVersion(ctx *ginx.Context, req DeleteVersionReq) (ginx.R
 	}, nil
 }
 
-// UpdatePrompt 更新 prompt 的基本信息
+// UpdatePrompt 处理更新提示基本信息的 HTTP 请求
 func (h *Handler) UpdatePrompt(ctx *ginx.Context, req UpdatePromptReq) (ginx.Result, error) {
 	prompt := domain.Prompt{
 		ID:          req.ID,
@@ -110,6 +118,7 @@ func (h *Handler) UpdatePrompt(ctx *ginx.Context, req UpdatePromptReq) (ginx.Res
 	}, nil
 }
 
+// UpdateVersion 处理更新提示版本信息的 HTTP 请求
 func (h *Handler) UpdateVersion(ctx *ginx.Context, req UpdateVersionReq) (ginx.Result, error) {
 	version := domain.PromptVersion{
 		ID:            req.VersionID,
@@ -128,6 +137,7 @@ func (h *Handler) UpdateVersion(ctx *ginx.Context, req UpdateVersionReq) (ginx.R
 	}, nil
 }
 
+// Publish 处理发布特定提示版本的 HTTP 请求
 func (h *Handler) Publish(ctx *ginx.Context, req PublishReq) (ginx.Result, error) {
 	err := h.svc.Publish(ctx, req.VersionID, req.Label)
 	if err != nil {
@@ -138,7 +148,7 @@ func (h *Handler) Publish(ctx *ginx.Context, req PublishReq) (ginx.Result, error
 	}, nil
 }
 
-// Fork 新增一个版本
+// Fork 处理复制（fork）提示版本的 HTTP 请求
 func (h *Handler) Fork(ctx *ginx.Context, req ForkReq) (ginx.Result, error) {
 	err := h.svc.Fork(ctx, req.VersionID)
 	if err != nil {

--- a/internal/web/infra/redis.go
+++ b/internal/web/infra/redis.go
@@ -1,9 +1,16 @@
 package infra
 
-import "github.com/redis/go-redis/v9"
+import (
+	"github.com/redis/go-redis/v9"
+)
 
+// rdb 是全局的 Redis 命令执行器实例
+// 用于在整个项目中执行 Redis 操作
 var rdb redis.Cmdable
 
+// InitRedis 初始化 Redis 客户端
+// 如果已经存在一个客户端实例则直接返回，否则创建一个新的客户端实例
+// 默认连接本地 Redis 服务（localhost:6379）
 func InitRedis() redis.Cmdable {
 	if rdb != nil {
 		return rdb

--- a/internal/web/infra/session.go
+++ b/internal/web/infra/session.go
@@ -6,6 +6,9 @@ import (
 	"time"
 )
 
+// Init 初始化会话提供者
+// 使用 Redis 创建一个新的会话提供者并设置为默认提供者
+// 密钥用于加密会话数据，过期时间设置为 1 小时
 func Init() {
 	provider := redis2.NewSessionProvider(InitRedis(), "VGhpcyBpcyBhIHNlY3JldCB0aGF0IG5vYm9keSBjYW4gZ3Vlc3M=", time.Hour)
 	session.SetDefaultProvider(provider)

--- a/internal/web/result.go
+++ b/internal/web/result.go
@@ -5,6 +5,8 @@ import (
 	"github.com/ecodeclub/ginx"
 )
 
+// systemErrorResult 定义系统错误时返回的标准结果
+// 包含错误码和错误信息，用于统一处理服务器内部错误
 var (
 	systemErrorResult = ginx.Result{
 		Code: errs.SystemError.Code,

--- a/internal/web/vo.go
+++ b/internal/web/vo.go
@@ -5,6 +5,11 @@ import (
 	"github.com/ecodeclub/ekit/slice"
 )
 
+// Package web 定义了 Web 层的处理器和路由
+// vo.go 定义了值对象（Value Object）用于在不同层之间传输数据
+
+// PromptVO 定义提示信息的值对象
+// 用于在不同层之间传输提示数据，包括基本信息和多个版本信息
 type PromptVO struct {
 	ID            int64             `json:"id"`
 	Name          string            `json:"name"`
@@ -17,6 +22,8 @@ type PromptVO struct {
 	UpdateTime    int64             `json:"update_time"`
 }
 
+// PromptVersionVO 定义提示版本的值对象
+// 用于在不同层之间传输提示版本的具体内容
 type PromptVersionVO struct {
 	ID            int64   `json:"id"`
 	Label         string  `json:"label"`
@@ -30,6 +37,7 @@ type PromptVersionVO struct {
 	UpdateTime    int64   `json:"utime"`
 }
 
+// newPromptVO 将领域模型转换为提示值对象
 func newPromptVO(p domain.Prompt) PromptVO {
 	versions := make([]PromptVersionVO, len(p.Versions))
 	for i, v := range p.Versions {
@@ -59,6 +67,7 @@ func newPromptVO(p domain.Prompt) PromptVO {
 	}
 }
 
+// AddReq 定义添加提示的请求参数结构体
 type AddReq struct {
 	Name          string  `json:"name"`
 	Content       string  `json:"content"`
@@ -69,36 +78,43 @@ type AddReq struct {
 	MaxTokens     int     `json:"max_tokens"`
 }
 
+// DeleteReq 定义删除提示的请求参数结构体
 type DeleteReq struct {
 	ID int64 `json:"id"`
 }
 
+// DeleteVersionReq 定义删除提示版本的请求参数结构体
 type DeleteVersionReq struct {
 	VersionID int64 `json:"version_id"`
 }
 
+// UpdatePromptReq 定义更新提示基本信息的请求参数结构体
 type UpdatePromptReq struct {
 	ID          int64  `json:"id,omitempty"`
 	Name        string `json:"name,omitempty"`
 	Description string `json:"description,omitempty"`
 }
 
+// SaveGraphReq 定义保存图信息的请求参数结构体
 type SaveGraphReq struct {
 	ID    int64  `json:"id"`
 	Steps []Node `json:"steps"`
 	Edges []Edge `json:"edges"`
 }
 
+// GraphVO 定义图信息的值对象
 type GraphVO struct {
 	ID    int64  `json:"id"`
 	Nodes []Node `json:"steps"`
 	Edges []Edge `json:"edges"`
 }
 
+// GetReq 定义获取图或提示信息的请求参数结构体
 type GetReq struct {
 	ID int64 `json:"id"`
 }
 
+// Node 定义节点信息的值对象
 type Node struct {
 	ID       int64  `json:"id,omitempty"`
 	GraphID  int64  `json:"graph_id,omitempty"`
@@ -107,6 +123,7 @@ type Node struct {
 	Metadata string `json:"metadata,omitempty"`
 }
 
+// Edge 定义边信息的值对象
 type Edge struct {
 	ID       int64  `json:"id,omitempty"`
 	GraphID  int64  `json:"graph_id,omitempty"`
@@ -115,6 +132,7 @@ type Edge struct {
 	Metadata string `json:"metadata,omitempty"`
 }
 
+// newGetNodeVO 将领域模型转换为图值对象
 func newGetNodeVO(plan domain.Graph) GraphVO {
 	var vo GraphVO
 	vo.ID = plan.ID
@@ -129,6 +147,7 @@ func newGetNodeVO(plan domain.Graph) GraphVO {
 	return vo
 }
 
+// UpdateVersionReq 定义更新提示版本信息的请求参数结构体
 type UpdateVersionReq struct {
 	VersionID     int64   `json:"version_id,omitempty"`
 	Content       string  `json:"content,omitempty"`
@@ -138,11 +157,13 @@ type UpdateVersionReq struct {
 	MaxTokens     int     `json:"max_tokens"`
 }
 
+// PublishReq 定义发布特定提示版本的请求参数结构体
 type PublishReq struct {
 	VersionID int64  `json:"version_id"`
 	Label     string `json:"label"`
 }
 
+// ForkReq 定义复制（fork）提示版本的请求参数结构体
 type ForkReq struct {
 	VersionID int64 `json:"version_id"`
 }


### PR DESCRIPTION
- 新增 LLMRequest、StreamEvent 和 LLMResponse消息类型
- 定义 AIService 服务，包括 Invoke 和 Stream 方法
- 生成对应的 gRPC 服务器和客户端代码
- 添加数据库模型和操作方法
- 实现基本的业务配置和提示模板功能